### PR TITLE
Add middlewares and adjust bot setup

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,7 @@ token = "token"
 drop_pending = true
 use_webhook = false
 use_class_middlewares = true
+actions_timeout = 0.2
 
 logger.name = "BotLogger"
 logger.level = "INFO"
@@ -49,3 +50,16 @@ level = "INFO"
 stream = "stdout"
 file_path = "logs/fair.log"
 format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+[messages]
+welcome = "Welcome"
+unregistered_help = "Unregistered help"
+player_help = "Player help"
+manager_help = "Manager help"
+unknown_error = "Unknown error"
+
+[buttons]
+reg_player = "Register as player"
+reg_manager = "Register as manager"
+help = "Help"
+cancel = "Cancel"

--- a/config_env_mapping.toml
+++ b/config_env_mapping.toml
@@ -3,6 +3,7 @@ token = "BOT_TOKEN"
 drop_pending = "BOT_DROP_PENDING"
 use_webhook = "BOT_USE_WEBHOOK"
 use_class_middlewares = "BOT_USE_CLASS_MIDDLEWARES"
+actions_timeout = "BOT_ACTIONS_TIMEOUT"
 
 logger.name = "BOT_LOGGER_NAME"
 logger.level = "BOT_LOGGER_LEVEL"
@@ -49,3 +50,16 @@ level = "LOGGER_LEVEL"
 stream = "LOGGER_STREAM"
 file_path = "LOGGER_FILE_PATH"
 format = "LOGGER_FORMAT"
+
+[messages]
+welcome = "MESSAGES_WELCOME"
+unregistered_help = "MESSAGES_UNREGISTERED_HELP"
+player_help = "MESSAGES_PLAYER_HELP"
+manager_help = "MESSAGES_MANAGER_HELP"
+unknown_error = "MESSAGES_UNKNOWN_ERROR"
+
+[buttons]
+reg_player = "BUTTONS_REG_PLAYER"
+reg_manager = "BUTTONS_REG_MANAGER"
+help = "BUTTONS_HELP"
+cancel = "BUTTONS_CANCEL"

--- a/fair/bot/__init__.py
+++ b/fair/bot/__init__.py
@@ -61,7 +61,7 @@ def setup_bot(
 
     add_custom_filters(bot)
     if bot_config.use_class_middlewares:
-        setup_middlewares(bot, messages.anti_flood, 0.2, db_adapter, messages, buttons, logger)
+        setup_middlewares(bot, messages.anti_flood, bot_config.actions_timeout, db_adapter, messages, buttons, logger)
     register_handlers(bot, buttons)
 
     return bot

--- a/fair/bot/__init__.py
+++ b/fair/bot/__init__.py
@@ -1,8 +1,10 @@
+import logging
 from typing import Optional
 
 from telebot import TeleBot
 
-from fair.config import BotConfig, BotWebhookConfig
+from fair.config import BotConfig, BotWebhookConfig, MessagesConfig, ButtonsConfig
+from fair.db import DBAdapter
 
 from fair.bot.filters import add_custom_filters
 from fair.bot.handlers import register_handlers
@@ -48,13 +50,18 @@ def stop_bot(bot: TeleBot, use_webhook: bool):
         bot.stop_polling()
 
 
-def setup_bot(bot_config: BotConfig):
+def setup_bot(
+        bot_config: BotConfig,
+        db_adapter: DBAdapter,
+        messages: MessagesConfig,
+        buttons: ButtonsConfig,
+        logger: logging.Logger):
     state_storage = setup_state_storage(bot_config.state_storage)
     bot = TeleBot(bot_config.token, state_storage=state_storage, use_class_middlewares=bot_config.use_class_middlewares)
 
     add_custom_filters(bot)
     if bot_config.use_class_middlewares:
-        setup_middlewares(bot)
-    register_handlers(bot)
+        setup_middlewares(bot, messages.anti_flood, 0.2, db_adapter, messages, buttons, logger)
+    register_handlers(bot, buttons)
 
     return bot

--- a/fair/bot/handlers/__init__.py
+++ b/fair/bot/handlers/__init__.py
@@ -1,6 +1,8 @@
 from telebot import TeleBot
 
+from fair.config import ButtonsConfig
 
-def register_handlers(bot: TeleBot):
+
+def register_handlers(bot: TeleBot, buttons: ButtonsConfig):
     # register all handlers here
     pass

--- a/fair/bot/middlewares/__init__.py
+++ b/fair/bot/middlewares/__init__.py
@@ -1,7 +1,25 @@
+import logging
+
 from telebot import TeleBot
 
+from fair.db import DBAdapter
+from fair.config import MessagesConfig, ButtonsConfig
 
-def setup_middlewares(bot: TeleBot):
+from fair.bot.middlewares.message_antiflood import MessageAntiFloodMiddleware
+from fair.bot.middlewares.callback_query_antiflood import CallbackQueryAntiFloodMiddleware
+from fair.bot.middlewares.extra_arguments import ExtraArgumentsMiddleware
+
+
+def setup_middlewares(
+        bot: TeleBot,
+        timeout_message: str,
+        timeout: float,
+        db_adapter: DBAdapter,
+        messages: MessagesConfig,
+        buttons: ButtonsConfig,
+        logger: logging.Logger):
     # setup all middlewares here
-    # bot.setup_middleware(YourMiddleware(...))
+    bot.setup_middleware(MessageAntiFloodMiddleware(bot, timeout_message, timeout))
+    bot.setup_middleware(CallbackQueryAntiFloodMiddleware(bot, timeout_message, timeout))
+    bot.setup_middleware(ExtraArgumentsMiddleware(db_adapter, messages, buttons, logger))
     pass

--- a/fair/bot/middlewares/callback_query_antiflood.py
+++ b/fair/bot/middlewares/callback_query_antiflood.py
@@ -1,0 +1,33 @@
+import time
+
+from telebot import TeleBot
+from telebot.types import CallbackQuery
+from telebot.handler_backends import BaseMiddleware, CancelUpdate
+
+
+class CallbackQueryAntiFloodMiddleware(BaseMiddleware):
+    def __init__(self, bot: TeleBot, timeout_message: str, timeout: float):
+        super().__init__()
+        self.bot = bot
+        self.timeout_message = timeout_message
+        self.timeout = timeout
+        self.update_types = ['callback_query']
+        self.last_query = {}
+
+    # argument naming is kept from the base class to avoid possible errors if passed as kwargs
+    def pre_process(self, message: CallbackQuery, data: dict):
+        now = time.time()
+        if message.from_user.id not in self.last_query:
+            self.last_query[message.from_user.id] = now
+            self.bot.answer_callback_query(message.id)  # always answer callback query
+            return
+        if now - self.last_query[message.from_user.id] < self.timeout:
+            self.last_query[message.from_user.id] = now
+            self.bot.answer_callback_query(message.id, self.timeout_message, show_alert=True)
+            return CancelUpdate()
+        self.last_query[message.from_user.id] = now
+        self.bot.answer_callback_query(message.id)  # always answer callback query
+
+    # argument naming is kept from the base class to avoid possible errors if passed as kwargs
+    def post_process(self, message: CallbackQuery, data: dict, exception: BaseException):
+        pass

--- a/fair/bot/middlewares/extra_arguments.py
+++ b/fair/bot/middlewares/extra_arguments.py
@@ -1,0 +1,27 @@
+import logging
+
+from telebot.types import Update
+from telebot.handler_backends import BaseMiddleware
+
+from fair.config import MessagesConfig, ButtonsConfig
+from fair.db import DBAdapter
+
+
+class ExtraArgumentsMiddleware(BaseMiddleware):
+    def __init__(self, db_adapter: DBAdapter, messages: MessagesConfig, buttons: ButtonsConfig, logger: logging.Logger):
+        super().__init__()
+        self.db_adapter = db_adapter
+        self.messages = messages
+        self.buttons = buttons
+        self.logger = logger
+        self.update_types = ['message', 'callback_query']
+
+    def pre_process(self, message: Update, data: dict):
+        # passing extra arguments to handlers
+        data['db_adapter'] = self.db_adapter
+        data['messages'] = self.messages
+        data['buttons'] = self.buttons
+        data['logger'] = self.logger
+
+    def post_process(self, message: Update, data: dict, exception: BaseException):
+        pass

--- a/fair/bot/middlewares/message_antiflood.py
+++ b/fair/bot/middlewares/message_antiflood.py
@@ -1,0 +1,26 @@
+from telebot import TeleBot
+from telebot.types import Message
+from telebot.handler_backends import BaseMiddleware, CancelUpdate
+
+
+class MessageAntiFloodMiddleware(BaseMiddleware):
+    def __init__(self, bot: TeleBot, timeout_message: str, timeout: float):
+        super().__init__()
+        self.bot = bot
+        self.timeout_message = timeout_message
+        self.timeout = timeout
+        self.last_message = {}
+        self.update_types = ['message']
+
+    def pre_process(self, message: Message, data: dict):
+        if message.from_user.id not in self.last_message:
+            self.last_message[message.from_user.id] = message.date
+            return
+        if message.date - self.last_message[message.from_user.id] < self.timeout:
+            self.last_message[message.from_user.id] = message.date
+            self.bot.send_message(message.chat.id, self.timeout_message)
+            return CancelUpdate()
+        self.last_message[message.from_user.id] = message.date
+
+    def post_process(self, message: Message, data: dict, exception: BaseException):
+        pass

--- a/fair/config/__init__.py
+++ b/fair/config/__init__.py
@@ -5,7 +5,7 @@ from typing import Optional
 from adaptix import Retort
 
 from fair.config.models import (
-    Config, BotConfig, DBConfig, LoggerConfig,
+    Config, BotConfig, DBConfig, LoggerConfig, MessagesConfig, ButtonsConfig,
     BotWebhookConfig, BotStateStorageConfig, RedisConfig
 )
 

--- a/fair/config/models.py
+++ b/fair/config/models.py
@@ -41,6 +41,7 @@ class BotConfig:
     drop_pending: bool  # Drop pending updates on startup
     use_webhook: bool  # Use webhook, otherwise long polling
     use_class_middlewares: bool  # Use class middlewares if any
+    actions_timeout: float  # Timeout between user's actions in seconds
     logger: LoggerConfig  # Logger config for the bot
     allowed_updates: Optional[Union[list[str], Literal['ALL']]] = None  # by default all except chat_member
     state_storage: Optional[BotStateStorageConfig] = None  # Bot state storage config if any
@@ -59,8 +60,28 @@ class DBConfig:
 
 
 @dataclass
+class MessagesConfig:
+    welcome: str
+    unregistered_help: str
+    player_help: str
+    manager_help: str
+    anti_flood: str
+    unknown_error: str
+
+
+@dataclass
+class ButtonsConfig:
+    reg_player: str
+    reg_manager: str
+    help: str
+    cancel: str
+
+
+@dataclass
 class Config:
     bot: BotConfig
     db: DBConfig
     # Extra configs if any
     logger: LoggerConfig  # Logger config for the app
+    messages: MessagesConfig  # Messages text config
+    buttons: ButtonsConfig  # Buttons text config


### PR DESCRIPTION
- Message anti-flood
- Callback query anti-flood
- Extra arguments for handlers

Add required arguments to the `bot:setup_bot()` and `bot:middlewares:setup_middlewares()`
Add `buttons` argument to the `bot:register_handlers` to be used for text filters instead of hard-coded values